### PR TITLE
Throw an exception if there are no matching routes found.

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -7,6 +7,14 @@
         [clojure.string :only [join]]))
 
 (def ^:dynamic *fake-routes* {})
+(def ^:dynamic *in-isolation* false)
+
+(defmacro with-fake-routes-in-isolation
+  "Makes all wrapped clj-http requests first match against given routes.
+  If no route matches, an exception is thrown."
+  [routes & body]
+  `(binding [*in-isolation* true]
+    (with-fake-routes ~routes ~@body)))
 
 (defmacro with-fake-routes
   "Makes all wrapped clj-http requests first match against given routes.
@@ -63,8 +71,13 @@
     (let [route-handler (val matching-route)
           response (route-handler request)]
       (assoc response :body (util/utf8-bytes (:body response))))
-    (origfn request)))
+    (if *in-isolation*
+      (throw (Exception. "No matching fake route found to handle request."))
+      (origfn request))))
 
-(add-hook
- #'clj-http.core/request
- #'try-intercept)
+(defn initialise-request-hook []
+  (add-hook
+   #'clj-http.core/request
+   #'try-intercept))
+
+(initialise-request-hook)

--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -1,5 +1,7 @@
 (ns clj-http.test.fake
-  (:require [clj-http.client :as http])
+  (:require [clj-http.client :as http]
+            [clj-http.core :as core]
+            [clj-http.util :as util])
   (:use [clj-http.fake]
         [clojure.test]))
 
@@ -52,3 +54,23 @@
             (fn [request]
               {:status 200 :headers {} :body "UrIrHi"})}
            (:body (http/get "http://google.com/index.html"))) "UrIrHi")))
+
+(deftest falls-through-to-real-request-method-if-no-matching-route
+  (with-redefs [clj-http.core/request
+                (fn [req]
+                  {:status 200 :headers {} :body (util/utf8-bytes "zgBOaC")})]
+    (initialise-request-hook)
+    (with-fake-routes
+      {"http://idontmatch.com" (fn [req] {:status 200 :headers {} :body "wp8gJf"})}
+      (is (= (:body (http/get "http://somerandomhost.org")) "zgBOaC")))))
+
+(deftest throws-exception-if-in-isolation-mode-and-no-matching-route
+  (with-redefs [clj-http.core/request
+                (fn [req]
+                  {:status 200 :headers {} :body (util/utf8-bytes "1Z6xAB")})]
+    (initialise-request-hook)
+    (with-fake-routes-in-isolation
+      {"http://idontmatch.com"
+       (fn [req]
+         {:status 200 :headers {} :body "lL4QSc"})}
+      (is (thrown? Exception (http/get "http://somerandomhost.org"))))))


### PR DESCRIPTION
Adding support for working in isolation and throwing an exception if no matching route is found for a particular request as discussed in issue #3.

Note, I couldn't work out how to use the syntax previously proposed so had to introduce a second macro. Any feedback welcome.

Thanks,
Toby
