### PR TITLE
Global alternatives to route-faking macros

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -20,11 +20,22 @@
   "Makes all wrapped clj-http requests first match against given routes.
   The actual HTTP request will be sent only if no matches are found."
   [routes & body]
-  `(do
-     (let [s# ~routes]
-       (assert (map? s#))
-       (binding [*fake-routes* s#]
-         ~@body))))
+  `(let [s# ~routes]
+    (assert (map? s#))
+    (binding [*fake-routes* s#]
+      ~@body)))
+
+(defmacro with-global-fake-routes-in-isolation
+  [routes & body]
+  `(with-redefs [*in-isolation* true]
+     (with-global-fake-routes ~routes ~@body)))
+
+(defmacro with-global-fake-routes
+  [routes & body]
+  `(let [s# ~routes]
+     (assert (map? s#))
+     (with-redefs [*fake-routes* s#]
+       ~@body)))
 
 (defn- defaults-or-value [defaults value]
   (if (contains? defaults value) (reverse (vec defaults)) (vector value)))


### PR DESCRIPTION
Some testing tools such as html-unit can make requests in other threads such that setting the fake routes with (binding ...) does not work.
