### PR TITLE
Can we make the question mark optional when the query-string is empty?

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -49,12 +49,16 @@
 (defn- potential-schemes-for [request-map]
   (defaults-or-value #{:http nil} (keyword (:scheme request-map))))
 
+(defn- potential-query-strings-for [request-map]
+  (defaults-or-value #{"" nil} (:query-string request-map)))
+
 (defn- potential-alternatives-to [request]
-  (let [schemes      (potential-schemes-for      request)
-        server-ports (potential-server-ports-for request)
-        uris         (potential-uris-for         request)
-        combinations (cartesian-product schemes server-ports uris)]
-    (map #(merge request (zipmap [:scheme :server-port :uri] %)) combinations)))
+  (let [schemes       (potential-schemes-for       request)
+        server-ports  (potential-server-ports-for  request)
+        uris          (potential-uris-for          request)
+        query-strings (potential-query-strings-for request)
+        combinations  (cartesian-product schemes server-ports uris query-strings)]
+    (map #(merge request (zipmap [:scheme :server-port :uri :query-string] %)) combinations)))
 
 (defn- address-string-for [request-map]
   (let [{:keys [scheme server-name server-port uri query-string]} request-map]

--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -130,3 +130,8 @@
               {:status 200 :headers {} :body "29RQPV"})}
            @(other-thread (:body (http/get "http://floatboth.com:2020/path/resource.ext?key=value"))))
          "29RQPV")))
+
+(deftest get-request-contains-empty-query-params
+  (is (= (with-fake-routes-in-isolation
+           {#".*/foo/bar" (constantly {:status 200 :headers {} :body "that's my foo bar"})}
+           (:body (http/get "http://floatboth.com/achey/breaky/foo/bar" {:query-params {}}))))))


### PR DESCRIPTION
If the request comes in with a :query-string of "" (as happens if you pass {:query-params {}} to clj-http.client/get), we should be able to match the url with or without a question-mark at the end.

At least I think so.
