### PR TITLE
Adding some details to the error message when running in isolation

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -116,6 +116,3 @@
    #'try-intercept))
 
 (initialize-request-hook)
-
-
-


### PR DESCRIPTION
Sorry for spamming with pull requests. 

I may actually push a couple if they're proper / when they're ready.

Just a bit more details, as it's hard to understand why exactly request did not go through.

Now you can see the details of the request when it fails in isolated mode:

```
java.lang.Exception: No matching fake route found to handle request. Reuqest details: 
    [:query-string "client_id=b4899ca55bb8403cfcf34fc424302f7c&offset=0&limit=10"] 
    [:uri "/users.json"] 
    [:server-name "api.sandbox-soundcloud.com"] 
    [:request-method :get] 
    [:scheme :http]
```
