### PR TITLE
Add passing query parameters as a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ In your namespace declaration:
   ;; Match multiple HTTP methods:
   "http://doogle.com/" {:get    (fn [req] {:status 200 :headers {} :body "Nah, that can't be Google!"})
                         :delete (fn [req] {:status 401 :headers {} :body "Do you think you can delete me?!"})}
+
+  ;; Match using query params as a map
+   {:address "http://google.com/search
+    :query-params {:q "aardark"}} (fn [req] {:status 200 :headers {} :body "Searches have results" }
  }
  ;; Your tests with requests here
  )

--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -1,5 +1,6 @@
 (ns clj-http.fake
-  (:import [java.util.regex Pattern])
+  (:import [java.util.regex Pattern]
+           [java.util Map])
   (:require [clj-http.client :as client]
             [clj-http.util :as util])
   (:use [robert.hooke]
@@ -86,7 +87,13 @@
     (let [request-method (:request-method request)
           address-strings (map address-string-for (potential-alternatives-to request))]
       (and (contains? (set (distinct [:any request-method])) method)
-           (some #(re-matches address %) address-strings)))))
+           (some #(re-matches address %) address-strings))))
+  Map
+  (matches [address method request]
+    (let [query-string (client/generate-query-string (:query-params address))
+          url (str (:address address) "?" query-string)]
+      (matches url method request))))
+
 
 (defn- flatten-routes [routes]
   (let [normalised-routes

--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -148,23 +148,32 @@
            {"http://google.com/?fst=test1&sec=test2"
             (fn [request]
               {:status 200 :headers {} :body "ASd0gf"})}
-           (:body (http/get "http://google.com/" {:query-params {:fst "test1", 
+           (:body (http/get "http://google.com/" {:query-params {:fst "test1",
                                                                  :sec "test2"}}))) "ASd0gf"))
   (is (= (with-fake-routes
            {"http://google.com/?sec=test2&fst=test1"
             (fn [request]
               {:status 200 :headers {} :body "oDKL13"})}
-           (:body (http/get "http://google.com/" {:query-params {:fst "test1", 
+           (:body (http/get "http://google.com/" {:query-params {:fst "test1",
                                                                  :sec "test2"}}))) "oDKL13"))
   (is (= (with-fake-routes
            {"http://google.com/?fst=test1&sec=test2"
             (fn [request]
               {:status 200 :headers {} :body "BXC9ai"})}
-           (:body (http/get "http://google.com/" {:query-params {:sec "test2", 
+           (:body (http/get "http://google.com/" {:query-params {:sec "test2",
                                                                  :fst "test1"}}))) "BXC9ai"))
   (is (= (with-fake-routes
            {"http://google.com/?sec=test2&fst=test1"
             (fn [request]
               {:status 200 :headers {} :body "91nOjA"})}
-           (:body (http/get "http://google.com/" {:query-params {:sec "test2", 
+           (:body (http/get "http://google.com/" {:query-params {:sec "test2",
                                                                  :fst "test1"}}))) "91nOjA")))
+
+(deftest query-params-specified-as-map
+  (is (= (with-fake-routes-in-isolation
+           {{:address "http://google.com/search"
+             :query-params {:q "aardvark"}}
+            (fn [request]
+              {:status 200 :headers {} :body "anteater"})}
+           (:body (http/get "http://google.com/search" {:query-params {:q "aardvark"}}))) "anteater")))
+


### PR DESCRIPTION
Allows you to pass query parameters as a map rather than a string on the end of a URL, this is useful in tests because it's irritating to have to write out the whole url for lots of arguments. I have added some examples to the documentation.

```
(with-fake-routes 
  {:address "http://google.com/search
  :query-params {:q "aardark"}} (fn [req] {:status 200 :headers {} :body "Searches have results" })
```
