### PR TITLE
Convert request body from HttpEntity to InputStream

### DIFF
--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -143,6 +143,13 @@
               {:status 200 :headers {} :body "4XbAfG"})}
            (:body (http/get "http://google.com/" {:query-params {:test "test"}}))) "4XbAfG")))
 
+(deftest request-contains-form-params
+  (is (= (with-fake-routes
+           {"http://google.com/"
+            (fn [request]
+              {:status 200 :headers {} :body (slurp (:body request))})}
+           (:body (http/post "http://google.com/" {:form-params {:test "4XbAfG"}}))) "test=4XbAfG")))
+
 (deftest request-query-param-order-does-not-matter
   (is (= (with-fake-routes
            {"http://google.com/?fst=test1&sec=test2"


### PR DESCRIPTION
The ring spec [1] states that the request body should be of type
InputStream.  However, clj-http.client/post and similar wrap their
request bodies in an HttpEntity subclass such as StringEntity, meaning
that clj-http-fake doesn't work for POSTs and PUTs and other requests
which include a body.

Fixes #16.

Co-authored by @rnewstead1.

[1] https://github.com/ring-clojure/ring/blob/master/SPEC
