### PR TITLE
Upgrade combinatorics dependency

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url  "http://www.opensource.org/licenses/mit-license.php"
             :distribution :repo}
   :min-lein-version "2.0.0"
-  :dependencies [[org.clojure/math.combinatorics "0.0.7"]
+  :dependencies [[org.clojure/math.combinatorics "0.1.1"]
                  [robert/hooke "1.3.0"]]
   :aliases {"test-newest" ["with-profile" "newest,1.5:newest,1.6" "test"]
             "test-oldest" ["with-profile" "oldest,1.5:oldest,1.6" "test"]}


### PR DESCRIPTION
In particular because clojure 1.7 gives a warning about `update`,
and this is fixed in newer versions