### PR TITLE
Updated versions to latest of everything; fixed an issue we were having with AOT dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pom.xml
 /classes/
 .lein-failures
 .lein-deps-sum
+.classpath
+.project

--- a/project.clj
+++ b/project.clj
@@ -6,11 +6,13 @@
             :distribution :repo}
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/math.combinatorics "0.1.1"]
-                 [robert/hooke "1.3.0"]]
-  :aliases {"test-newest" ["with-profile" "newest,1.5:newest,1.6" "test"]
-            "test-oldest" ["with-profile" "oldest,1.5:oldest,1.6" "test"]}
-  :profiles {:1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
+                 [robert/hooke "1.3.0"]
+                 [clj-http "2.0.0"]]    ;; Needed here or lein might not compile clj-http first, resulting in broken builds
+  :aliases {"test-newest" ["with-profile" "newest,1.5:newest,1.6:newest,1.7" "test"]
+            "test-oldest" ["with-profile" "oldest,1.5:oldest,1.6:oldest,1.7" "test"]}
+  :profiles {:1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              ;;the newest supported version of clj-http
-             :newest {:dependencies [[clj-http "1.0.1"]]}
+             :newest {:dependencies [[clj-http "2.0.0"]]}
              :oldest {:dependencies [[clj-http "0.7.8"]]}})


### PR DESCRIPTION
* Added profile for 1.7
* Upgraded clj-http to 2.0.0
* Updated test aliases for new combinations
* Added clj-http as an explicit dependency.  (see comment below)
* Re-ran test-newest and test-oldest. :smile: 

(Not having clj-http as an explicit dependency was breaking our build because clj-http-fake was being compiled ahead of clj-http.)
