### PR TITLE
Added laziness to potential-alternatives-to

### DIFF
--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -7,6 +7,20 @@
         :reload-all)
   (:import (java.net ConnectException)))
 
+
+(deftest many-qparams-performance-test
+  (let [num-qparams 10]
+    (is (= (with-fake-routes
+             {#"http://test/\?.*"
+              (fn [request]
+                {:status 200 :headers {} :body "29RQPV"})}
+             (:body (http/request
+                      {:url "http://test/"
+                       :query-params (zipmap (map str (range 0 num-qparams))
+                                             (range 0 num-qparams))
+                       :method :get})))
+           "29RQPV"))))
+
 (deftest matches-route-exactly
   (is (= (with-fake-routes
            {"http://floatboth.com:2020/path/resource.ext?key=value"


### PR DESCRIPTION
Fixes myfreeweb/clj-http-fake#37

----

By making `potential-alternatives-to` use the laziness of `permutations` and `cartesian-product`, we are able to let the Pattern `RouteMatcher` terminate early if it doesn't specify a query param ordering.