### PR TITLE
Bump clj-http + test on Clojure 1.9 and 1.10

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -9,12 +9,14 @@
                  [robert/hooke "1.3.0"]
                  [clj-http "3.1.0"] ;; Needed here or lein might not compile clj-http first, resulting in broken builds
                  [ring/ring-codec "1.0.1"]]
-  :aliases {"test-2.x" ["with-profile" "latest-2.x,1.5:latest-2.x,1.6:latest-2.x,1.7:latest-2.x,1.8" "test"]
-            "test-3.x" ["with-profile" "latest-3.x,1.5:latest-3.x,1.6:latest-3.x,1.7:latest-3.x,1.8" "test"]}
-  :profiles {:1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+  :aliases {"test-2.x" ["with-profile" "latest-2.x,1.5:latest-2.x,1.6:latest-2.x,1.7:latest-2.x,1.8:latest-2.x,1.9:latest-2.x,1.10" "test"]
+            "test-3.x" ["with-profile" "latest-3.x,1.6:latest-3.x,1.7:latest-3.x,1.8:latest-3.x,1.9:latest-3.x,1.10" "test"]}
+  :profiles {:1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              ;;the latest supported versions of clj-http from the 2.x and 3.x releases:
              :latest-2.x {:dependencies [[clj-http "2.3.0"]]}
-             :latest-3.x {:dependencies [[clj-http "3.4.1"]]}})
+             :latest-3.x {:dependencies [[clj-http "3.10.0"]]}})


### PR DESCRIPTION
I had to remove `latest-3.x,1.5` from `test-3.x` because clj-http 3.x doesn’t support Clojure 1.5 anymore.