### PR TITLE
Resolve reflection warnings

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -148,7 +148,7 @@
 
 (defn- unwrap-body [request]
   (if (instance? HttpEntity (:body request))
-    (assoc request :body (.getContent (:body request)))
+    (assoc request :body (.getContent ^HttpEntity (:body request)))
     request))
 
 (defn- get-matching-route
@@ -168,6 +168,7 @@
 (defn- throw-no-fake-route-exception
   [request]
   (throw (Exception.
+           ^String
            (apply format
                   "No matching fake route found to handle request. Request details: \n\t%s \n\t%s \n\t%s \n\t%s \n\t%s "
                   (select-keys request [:scheme :request-method :server-name :uri :query-string])))))


### PR DESCRIPTION
Hi,

Thanks for clj-http-fake!

Requiring `clj-http.fake` with `(set! *warn-on-reflection* true)` points to a few reflective calls. This PR does the bare minimum needed to resolve these calls.

Thanks!
Ambrose