### PR TITLE
Allow non-string query param values to be specified in maps.

### DIFF
--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -93,7 +93,7 @@
   (let [actual-query-params (or (some-> request :query-string ring-codec/form-decode) {})]
     (and (= (count expected-query-params) (count actual-query-params))
          (every? (fn [[k v]]
-                   (= (str v) (get actual-query-params (if (string? k) k (name k)))))
+                   (= (str v) (get actual-query-params (name k))))
                  expected-query-params))))
 
 (extend-protocol RouteMatcher

--- a/src/clj_http/fake.clj
+++ b/src/clj_http/fake.clj
@@ -93,7 +93,7 @@
   (let [actual-query-params (or (some-> request :query-string ring-codec/form-decode) {})]
     (and (= (count expected-query-params) (count actual-query-params))
          (every? (fn [[k v]]
-                   (= v (get actual-query-params (if (string? k) k (name k)))))
+                   (= (str v) (get actual-query-params (if (string? k) k (name k)))))
                  expected-query-params))))
 
 (extend-protocol RouteMatcher

--- a/test/clj_http/test/fake.clj
+++ b/test/clj_http/test/fake.clj
@@ -216,7 +216,17 @@
                 {:status 200 :headers {} :body "anteater"})}
              (:body (http/get "http://google.com/search"
                               {:query-params {:q "this has spaces"}})))
-           "anteater"))))
+           "anteater")))
+
+  (testing "non-string query params specified as map"
+    (is (= (with-fake-routes-in-isolation
+             {{:address "http://google.com/blah"
+               :query-params {:a 1 :b true :c "c"}}
+              (fn [request]
+                {:status 200 :headers {} :body "Ya got me!"})}
+             (:body (http/get "http://google.com/blah"
+                              {:query-params {:a 1 :b true :c "c"}})))
+           "Ya got me!"))))
 
 (deftest get-as-byte-array
   (let [body (.getBytes "anteater")]


### PR DESCRIPTION
Converting expected query param values to strings before comparing them to actual query param values allows the same map to be passed to the request functions in `clj-http` and the `with-fake-routes` macros in `clj-http-fake`.

I also removed a type check that wasn't necessary (because calling `clojure.core/name` on a string simply returns the string).

All of the tests run by `lein test-2.x` and `lein test-3.x` are passing on my laptop. I don't know if there are any other tests that I should run, however. Please let me know if I've missed anything.
